### PR TITLE
[Feat]: fcm token 저장 로직 추가

### DIFF
--- a/src/main/java/org/scoula/domain/member/controller/FcmTokenController.java
+++ b/src/main/java/org/scoula/domain/member/controller/FcmTokenController.java
@@ -1,0 +1,36 @@
+package org.scoula.domain.member.controller;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+import org.scoula.domain.member.dto.request.FcmTokenRequest;
+import org.scoula.domain.member.service.MemberService;
+import org.scoula.global.response.SuccessResponse;
+import org.scoula.global.security.dto.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/fcm")
+@Api(tags = "fcm 토큰 저장", description = "fcm 토큰 저장 api")
+public class FcmTokenController {
+
+	private final MemberService memberService;
+
+	@PostMapping
+	@ApiOperation(value = "fcm 토큰 저장", notes = "fcm 토큰 저장 api.")
+	public SuccessResponse<Void> saveFcmToken(@RequestBody @Valid FcmTokenRequest fcmTokenRequest,
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		HttpServletRequest request) {
+		memberService.updateFcmToken(customUserDetails.getMember().getMemberId(), fcmTokenRequest.fcmToken());
+		return SuccessResponse.noContent();
+	}
+}

--- a/src/main/java/org/scoula/domain/member/dto/request/FcmTokenRequest.java
+++ b/src/main/java/org/scoula/domain/member/dto/request/FcmTokenRequest.java
@@ -1,0 +1,12 @@
+package org.scoula.domain.member.dto.request;
+
+import javax.validation.constraints.NotBlank;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public record FcmTokenRequest(
+	@NotBlank(message = "fcm 토큰은 필수로 넣어주셔야 합니다.")
+	@ApiModelProperty(value = "fcm 토큰", example = "발급받은 fcm 토큰 값", required = true)
+	String fcmToken
+) {
+}

--- a/src/main/java/org/scoula/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/org/scoula/domain/member/mapper/MemberMapper.java
@@ -36,6 +36,9 @@ public interface MemberMapper {
 	@Update("UPDATE member SET connected_id = #{connectedId} WHERE member_id = #{memberId}")
 	void updateConnectedId(@Param("memberId") Long memberId, @Param("connectedId") String connectedId);
 
+	@Update("UPDATE member SET fcm_token = #{fcmToken} WHERE member_id = #{memberId}")
+	void updateFcmToken(@Param("memberId") Long memberId, @Param("fcmToken") String fcmToken);
+
 	Optional<Member> selectMemberByPhoneNumber(String phoneNumber);
 
 	List<Member> selectMembersInIds(@Param("memberIds") List<Long> memberIds);

--- a/src/main/java/org/scoula/domain/member/service/MemberService.java
+++ b/src/main/java/org/scoula/domain/member/service/MemberService.java
@@ -26,6 +26,9 @@ public interface MemberService {
 	// 커넥티드 아이디 업데이트
 	void updateConnectedId(Long memberId, String connectedId);
 
+	// fcm token 업데이트
+	void updateFcmToken(Long memberId, String connectedId);
+
 	Member getMemberByPhoneNumber(String phoneNumber, HttpServletRequest request);
 
 }

--- a/src/main/java/org/scoula/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/scoula/domain/member/service/MemberServiceImpl.java
@@ -98,6 +98,12 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	@Override
+	@Transactional
+	public void updateFcmToken(Long memberId, String fcmToken) {
+		memberMapper.updateFcmToken(memberId, fcmToken);
+	}
+
+	@Override
 	public Member getMemberByPhoneNumber(String phoneNumber, HttpServletRequest request) {
 		return memberMapper.selectMemberByPhoneNumber(phoneNumber)
 			.orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND, LogLevel.WARNING, null, Common.builder()


### PR DESCRIPTION
## 📌 관련 이슈
<!--- 관련 이슈를 태그해주세요 -->
- #81 
> Close #81 

## 📄 PR 상세 내용
<!--- 작업에 대한 설명을 작성해 주세요. -->
- fcm 토큰을 유저 테이블에 저장하는 기능을 추가하였습니다.

## 📸 이미지 (테스트 이미지 필수)
<img width="1180" height="1460" alt="image" src="https://github.com/user-attachments/assets/294506cb-ebc8-41ba-b977-721c0452de67" />

