### PR TITLE
[Feat]: 차대변 정합성 검증을 위한 배치 기능 작성

### DIFF
--- a/src/main/java/org/scoula/domain/ledger/batch/config/LedgerBatchConfig.java
+++ b/src/main/java/org/scoula/domain/ledger/batch/config/LedgerBatchConfig.java
@@ -1,0 +1,64 @@
+package org.scoula.domain.ledger.batch.config;
+
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+import org.scoula.domain.ledger.batch.reader.LedgerIdRangePartitioner;
+import org.scoula.domain.transaction.entity.Transaction;
+import org.scoula.domain.transaction.mapper.TransactionMapper;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class LedgerBatchConfig {
+
+	private final MyBatisPagingItemReader<Transaction> transactionReader;
+	private final ItemWriter<Transaction> transactionWriter;
+	private final TransactionMapper transactionMapper;
+
+	private final JobRepository jobRepository;
+	private final PlatformTransactionManager transactionManager;
+	private final StepBuilderFactory stepBuilderFactory;
+	private final TaskExecutor taskExecutor;
+
+	private final int threadSize = 1;
+
+	@Bean
+	public Job ledgerValidBatchJob() {
+		return new JobBuilder("ledgerValidBatchJob")
+			.start(partitionedLedgerValidBatchStep())
+			.repository(jobRepository)
+			.build();
+	}
+
+	@Bean
+	public Step partitionedLedgerValidBatchStep() {
+		return stepBuilderFactory.get("partitionedLedgerValidBatchStep")
+			.partitioner("ledgerValidBatchStep", new LedgerIdRangePartitioner(transactionMapper))
+			.step(ledgerValidBatchStep())
+			.gridSize(threadSize)
+			.transactionManager(transactionManager)
+			.taskExecutor(taskExecutor)
+			.build();
+	}
+
+	@Bean
+	public Step ledgerValidBatchStep() {
+		return stepBuilderFactory.get("ledgerValidBatchStep")
+			.<Transaction, Transaction>chunk(1000000)
+			.reader(transactionReader)
+			.writer(transactionWriter)
+			.repository(jobRepository)
+			.transactionManager(transactionManager)
+			.build();
+	}
+}

--- a/src/main/java/org/scoula/domain/ledger/batch/dto/LedgerVoucherWithEntryDTO.java
+++ b/src/main/java/org/scoula/domain/ledger/batch/dto/LedgerVoucherWithEntryDTO.java
@@ -1,0 +1,22 @@
+package org.scoula.domain.ledger.batch.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.scoula.domain.ledger.entity.LedgerType;
+import org.scoula.domain.transaction.entity.TransactionType;
+
+import lombok.Data;
+
+@Data
+public class LedgerVoucherWithEntryDTO {
+	private Long ledgerVoucherId;
+	private String voucherNo;
+	private LocalDateTime entryDate;
+	private TransactionType type;
+
+	private Long ledgerEntryId;
+	private BigDecimal amount;
+	private LedgerType ledgerType;
+	private Long accountCodeId;
+}

--- a/src/main/java/org/scoula/domain/ledger/batch/reader/LedgerIdRangePartitioner.java
+++ b/src/main/java/org/scoula/domain/ledger/batch/reader/LedgerIdRangePartitioner.java
@@ -1,0 +1,44 @@
+package org.scoula.domain.ledger.batch.reader;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.scoula.domain.transaction.mapper.TransactionMapper;
+import org.springframework.batch.core.partition.support.Partitioner;
+import org.springframework.batch.item.ExecutionContext;
+
+public class LedgerIdRangePartitioner implements Partitioner {
+
+	private final TransactionMapper transactionMapper;
+
+	public LedgerIdRangePartitioner(TransactionMapper transactionMapper) {
+		this.transactionMapper = transactionMapper;
+	}
+
+	@Override
+	public Map<String, ExecutionContext> partition(int gridSize) {
+		Long minId = transactionMapper.findMinIdFromYesterday();
+		Long maxId = transactionMapper.findMaxIdFromYesterday();
+
+		Map<String, ExecutionContext> result = new HashMap<>();
+
+		if (minId == null || maxId == null) {
+			return result;
+		}
+
+		long targetSize = (maxId - minId) / gridSize + 1;
+		long start = minId;
+		long end = start + targetSize - 1;
+
+		for (int i = 0; i < gridSize; i++) {
+			ExecutionContext context = new ExecutionContext();
+			context.putLong("startId", start);
+			context.putLong("endId", Math.min(end, maxId));
+			result.put("partition" + i, context);
+			start += targetSize;
+			end += targetSize;
+		}
+
+		return result;
+	}
+}

--- a/src/main/java/org/scoula/domain/ledger/batch/reader/LedgerReader.java
+++ b/src/main/java/org/scoula/domain/ledger/batch/reader/LedgerReader.java
@@ -1,0 +1,38 @@
+package org.scoula.domain.ledger.batch.reader;
+
+import java.util.Map;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+import org.scoula.domain.transaction.entity.Transaction;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LedgerReader {
+
+	@Bean
+	@StepScope
+	public MyBatisPagingItemReader<Transaction> transactionReader(
+		@Value("#{stepExecutionContext['startId']}") Long startId,
+		@Value("#{stepExecutionContext['endId']}") Long endId,
+		@Qualifier("simpleSqlSessionFactory")
+		SqlSessionFactory sqlSessionFactory) {
+		try {
+			MyBatisPagingItemReader<Transaction> reader = new MyBatisPagingItemReader<>();
+			reader.setQueryId("org.scoula.domain.transaction.mapper.TransactionMapper.findByTransactionIdRange");
+			reader.setParameterValues(Map.of("startId", startId, "endId", endId));
+			reader.setSqlSessionFactory(sqlSessionFactory);
+			reader.setPageSize(1000000);
+			reader.setSaveState(false);
+			reader.setName("transactionReader");
+			return reader;
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+}

--- a/src/main/java/org/scoula/domain/ledger/batch/scheduler/LedgerValidateBatchScheduler.java
+++ b/src/main/java/org/scoula/domain/ledger/batch/scheduler/LedgerValidateBatchScheduler.java
@@ -1,0 +1,48 @@
+package org.scoula.domain.ledger.batch.scheduler;
+
+import java.time.LocalDateTime;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+
+import lombok.extern.log4j.Log4j2;
+
+@Component
+@Log4j2
+public class LedgerValidateBatchScheduler {
+
+	private final Job ledgerValidBatchJob;
+	private final JobLauncher jobLauncher;
+
+	public LedgerValidateBatchScheduler(@Qualifier("ledgerValidBatchJob") Job ledgerValidBatchJob,
+		JobLauncher jobLauncher) {
+		this.ledgerValidBatchJob = ledgerValidBatchJob;
+		this.jobLauncher = jobLauncher;
+	}
+
+	@Scheduled(cron = "0 0 4  * * *", zone = "Asia/Seoul")
+	@SchedulerLock(name = "runRemittanceGroupJobLock", lockAtMostFor = "PT10M") // 락 10분간 유지
+	public void runLedgerValidateJob() {
+		try {
+			log.info("[LedgerValidateBatchScheduler] 배치 시작");
+
+			JobParameters jobParameters = new JobParametersBuilder()
+				.addString("datetime", LocalDateTime.now().toString()) // 중복 실행 방지용
+				.toJobParameters();
+
+			JobExecution execution = jobLauncher.run(ledgerValidBatchJob, jobParameters);
+			log.info("[LedgerValidateBatchScheduler] 배치 종료. 상태: {}", execution.getStatus());
+
+		} catch (Exception e) {
+			log.error("[LedgerValidateBatchScheduler] 배치 실행 중 오류 발생", e);
+		}
+	}
+}

--- a/src/main/java/org/scoula/domain/ledger/batch/scheduler/LedgerValidateBatchScheduler.java
+++ b/src/main/java/org/scoula/domain/ledger/batch/scheduler/LedgerValidateBatchScheduler.java
@@ -2,6 +2,7 @@ package org.scoula.domain.ledger.batch.scheduler;
 
 import java.time.LocalDateTime;
 
+import org.scoula.global.exception.CustomException;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
@@ -41,8 +42,11 @@ public class LedgerValidateBatchScheduler {
 			JobExecution execution = jobLauncher.run(ledgerValidBatchJob, jobParameters);
 			log.info("[LedgerValidateBatchScheduler] 배치 종료. 상태: {}", execution.getStatus());
 
-		} catch (Exception e) {
+		} catch (CustomException e) {
 			log.error("[LedgerValidateBatchScheduler] 배치 실행 중 오류 발생", e);
+			throw e;
+		} catch (Exception e) {
+			throw new RuntimeException("LedgerValidateBatchScheduler 배치 실행 중 시스템 오류 발생", e);
 		}
 	}
 }

--- a/src/main/java/org/scoula/domain/ledger/batch/writer/LedgerWriter.java
+++ b/src/main/java/org/scoula/domain/ledger/batch/writer/LedgerWriter.java
@@ -1,0 +1,77 @@
+package org.scoula.domain.ledger.batch.writer;
+
+import static org.scoula.domain.ledger.exception.LedgerErrorCode.*;
+import static org.scoula.domain.transaction.entity.TransactionType.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.scoula.domain.ledger.batch.dto.LedgerVoucherWithEntryDTO;
+import org.scoula.domain.ledger.entity.LedgerType;
+import org.scoula.domain.ledger.service.LedgerService;
+import org.scoula.domain.transaction.entity.Transaction;
+import org.scoula.domain.transaction.entity.TransactionType;
+import org.scoula.domain.transaction.service.TransactionService;
+import org.scoula.global.exception.CustomException;
+import org.scoula.global.kafka.dto.Common;
+import org.scoula.global.kafka.dto.LogLevel;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class LedgerWriter {
+
+	private final TransactionService transactionService;
+	private final LedgerService ledgerService;
+
+	@Bean
+	@StepScope
+	public ItemWriter<Transaction> LedgerItemWriter() {
+
+		return transactions -> {
+			List<LedgerVoucherWithEntryDTO> ledgerVoucherWithEntryInYesterday = ledgerService.getLedgerVoucherWithEntryInYesterday();
+
+			checkOfTransactionTypeBalanced((List<Transaction>)transactions, ledgerVoucherWithEntryInYesterday, CHARGE);
+			checkOfTransactionTypeBalanced((List<Transaction>)transactions, ledgerVoucherWithEntryInYesterday,
+				ACCOUNT_TRANSFER);
+			checkOfTransactionTypeBalanced((List<Transaction>)transactions, ledgerVoucherWithEntryInYesterday,
+				WALLET_TRANSFER);
+			checkOfTransactionTypeBalanced((List<Transaction>)transactions, ledgerVoucherWithEntryInYesterday, DEPOSIT);
+			checkOfTransactionTypeBalanced((List<Transaction>)transactions, ledgerVoucherWithEntryInYesterday,
+				WITHDRAW);
+		};
+	}
+
+	private void checkOfTransactionTypeBalanced(List<Transaction> transactions,
+		List<LedgerVoucherWithEntryDTO> ledgerVoucherWithEntryInYesterday, TransactionType transactionType) {
+		BigDecimal sumOfTransaction = transactionService.getSumByTransactionType(transactionType, transactions);
+
+		BigDecimal sumOfLedgerDebit = ledgerService.getSumByTypes(transactionType, LedgerType.DEBIT,
+			ledgerVoucherWithEntryInYesterday);
+		BigDecimal sumOfLedgerCredit = ledgerService.getSumByTypes(transactionType, LedgerType.CREDIT,
+			ledgerVoucherWithEntryInYesterday);
+
+		boolean isMatch =
+			sumOfTransaction.compareTo(sumOfLedgerDebit) == 0 &&
+				sumOfTransaction.compareTo(sumOfLedgerCredit) == 0
+				&& sumOfLedgerDebit.compareTo(sumOfLedgerCredit) == 0;
+
+		if (!isMatch) {
+			throw new CustomException(LEDGER_BALANCED_BROKEN, LogLevel.ERROR, null, Common.builder().build(),
+				transactionType.name() + " 타입 정합성 검증 실패, 거래내역 합: " + sumOfTransaction
+					+ "\nDEBIT TYPE 합: " + sumOfLedgerDebit
+					+ "\nCREDIT TYPE 합: " + sumOfLedgerCredit);
+		} else {
+			log.info(
+				transactionType.name() + " 타입 정합성 검증 성공, 거래내역 합: " + sumOfTransaction + "\nDEBIT TYPE 합: "
+					+ sumOfLedgerDebit + "\nCREDIT TYPE 합: " + sumOfLedgerCredit);
+		}
+	}
+}

--- a/src/main/java/org/scoula/domain/ledger/exception/LedgerErrorCode.java
+++ b/src/main/java/org/scoula/domain/ledger/exception/LedgerErrorCode.java
@@ -1,0 +1,20 @@
+package org.scoula.domain.ledger.exception;
+
+import org.scoula.global.exception.errorCode.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum LedgerErrorCode implements ErrorCode {
+
+	LEDGER_BALANCED_BROKEN(HttpStatus.INTERNAL_SERVER_ERROR, "L-001", "차변 대변 정합성 검증에 실패하였습니다."),
+
+	;
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/org/scoula/domain/ledger/mapper/LedgerVoucherMapper.java
+++ b/src/main/java/org/scoula/domain/ledger/mapper/LedgerVoucherMapper.java
@@ -1,9 +1,29 @@
 package org.scoula.domain.ledger.mapper;
 
+import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+import org.scoula.domain.ledger.batch.dto.LedgerVoucherWithEntryDTO;
 import org.scoula.domain.ledger.entity.LedgerVoucher;
 
 @Mapper
 public interface LedgerVoucherMapper {
 	void insert(LedgerVoucher ledgerVoucher);
+
+	@Select("""
+			SELECT 
+				lv.ledger_voucher_id,
+				lv.voucher_no,
+				lv.entry_date,
+				lv.type,
+				le.ledger_entry_id,
+				le.amount,
+				le.ledger_type,
+				le.account_code_id
+			FROM ledger_voucher lv
+			JOIN ledger_entry le ON lv.ledger_voucher_id = le.ledger_voucher_id
+			WHERE DATE(lv.entry_date) = CURDATE() - INTERVAL 1 DAY
+		""")
+	List<LedgerVoucherWithEntryDTO> findAllFromYesterday();
 }

--- a/src/main/java/org/scoula/domain/ledger/service/LedgerService.java
+++ b/src/main/java/org/scoula/domain/ledger/service/LedgerService.java
@@ -1,8 +1,14 @@
 package org.scoula.domain.ledger.service;
 
+import java.math.BigDecimal;
+import java.util.List;
+
 import javax.servlet.http.HttpServletRequest;
 
+import org.scoula.domain.ledger.batch.dto.LedgerVoucherWithEntryDTO;
+import org.scoula.domain.ledger.entity.LedgerType;
 import org.scoula.domain.remittancegroup.batch.dto.MemberWithInformationDto;
+import org.scoula.domain.transaction.entity.TransactionType;
 import org.scoula.domain.wallet.dto.request.ChargeWalletRequest;
 import org.scoula.domain.wallet.dto.request.TransferToAccountRequest;
 import org.scoula.domain.wallet.dto.request.TransferToWalletRequest;
@@ -18,4 +24,8 @@ public interface LedgerService {
 
 	void chargeTransfer(ChargeWalletRequest request, String transactionGroupId, HttpServletRequest servletRequest);
 
+	List<LedgerVoucherWithEntryDTO> getLedgerVoucherWithEntryInYesterday();
+
+	BigDecimal getSumByTypes(TransactionType transactionType, LedgerType ledgerType,
+		List<LedgerVoucherWithEntryDTO> dtoList);
 }

--- a/src/main/java/org/scoula/domain/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/org/scoula/domain/transaction/mapper/TransactionMapper.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
 import org.scoula.domain.transaction.entity.Transaction;
 import org.scoula.domain.transaction.entity.TransactionType;
 import org.scoula.global.constants.SortDirection;
@@ -38,5 +39,32 @@ public interface TransactionMapper {
 		@Param("limit") Integer limit,
 		@Param("offset") Integer offset
 	);
+
+	@Select("""
+		    SELECT MIN(transaction_id) 
+		    FROM transaction 
+		    WHERE DATE(created_at) = DATE_SUB(CURDATE(), INTERVAL 1 DAY)
+		""")
+	Long findMinIdFromYesterday();
+
+	@Select("""
+		    SELECT MAX(transaction_id) 
+		    FROM transaction 
+		    WHERE DATE(created_at) = DATE_SUB(CURDATE(), INTERVAL 1 DAY)
+		""")
+	Long findMaxIdFromYesterday();
+
+	@Select("""
+		    SELECT *
+		    FROM transaction
+		    WHERE DATE(created_at) = CURDATE() - INTERVAL 1 DAY
+		      AND transaction_id BETWEEN #{startId} AND #{endId}
+		    ORDER BY transaction_id
+		""")
+	List<Transaction> findByTransactionIdRange(
+		@Param("startId") Long startId,
+		@Param("endId") Long endId
+	);
+
 }
 

--- a/src/main/java/org/scoula/domain/transaction/service/TransactionService.java
+++ b/src/main/java/org/scoula/domain/transaction/service/TransactionService.java
@@ -33,4 +33,6 @@ public interface TransactionService {
 
 	Page<TransactionHistoryResponse> getTransactionHistory(Period period, TransactionType type,
 		BigDecimal minAmount, BigDecimal maxAmount, SortDirection sortDirection, int page, Integer size, Member member);
+
+	BigDecimal getSumByTransactionType(TransactionType type, List<Transaction> transactions);
 }

--- a/src/main/java/org/scoula/global/batch/config/BatchConfig.java
+++ b/src/main/java/org/scoula/global/batch/config/BatchConfig.java
@@ -2,6 +2,8 @@ package org.scoula.global.batch.config;
 
 import javax.sql.DataSource;
 
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
@@ -11,6 +13,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -24,6 +27,22 @@ public class BatchConfig {
 
 	private final DataSource dataSource;
 	private final PlatformTransactionManager transactionManager;
+
+	@Bean(name = "simpleSqlSessionFactory")
+	public SqlSessionFactory simpleSqlSessionFactory() throws Exception {
+		SqlSessionFactoryBean factoryBean = new SqlSessionFactoryBean();
+		factoryBean.setDataSource(dataSource);
+
+		factoryBean.setMapperLocations(
+			new PathMatchingResourcePatternResolver().getResources("classpath*:org/scoula/domain/**/*.xml")
+		);
+
+		factoryBean.setConfigLocation(
+			new PathMatchingResourcePatternResolver().getResource("classpath:mybatis-config.xml")
+		);
+
+		return factoryBean.getObject();
+	}
 
 	@Bean
 	public TaskExecutor taskExecutor() {

--- a/src/main/java/org/scoula/global/common/config/RootConfig.java
+++ b/src/main/java/org/scoula/global/common/config/RootConfig.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -42,6 +43,7 @@ import com.zaxxer.hikari.HikariDataSource;
 	// "org.scoula.service",
 	"org.scoula.domain.**.service",  // 도메인 객체를 포함하기 위해 추가
 	"org.scoula.domain.remittancegroup.batch", // spring batch 설정 추가
+	"org.scoula.domain.ledger.batch",
 	"org.scoula.global.swagger.config",  // Swagger 설정을 포함하기 위해 추가
 	"org.scoula.global.kafka", // kafka 설정 포함
 	"org.scoula.global.exception", // exception handler 등록
@@ -100,6 +102,7 @@ public class RootConfig {
 	}
 
 	@Bean
+	@Primary
 	public SqlSessionFactory sqlSessionFactory() throws Exception {
 		SqlSessionFactoryBean sqlSessionFactory = new SqlSessionFactoryBean();
 		sqlSessionFactory.setConfigLocation(


### PR DESCRIPTION
## 📌 관련 이슈
<!--- 관련 이슈를 태그해주세요 -->
- #95 
> Close #95 

## 📄 PR 상세 내용
<!--- 작업에 대한 설명을 작성해 주세요. -->
- 모든 구간의 합을 구해서 한 번에 검증해야하기에 단일 스레드로 진행하였습니다.
- 특정 타입의 거래내역의 합 == 특정 타입의 회계 차변의 합 == 특정 타입의 회계 대변의 합으로 검증하였습니다.
- 합이 일치하지 않을 시 바로 슬랙으로 알림이 가도록 구성하였습니다.
- 분산락을 사용해 중복 실행이 되지 않도록 하였습니다.

## 📸 이미지 (테스트 이미지 필수)
<img width="2452" height="946" alt="image" src="https://github.com/user-attachments/assets/d3924d2c-014a-4c62-b0e0-928c56fb5001" />
