### PR TITLE
[Feat]: 회원 자동 충전 배치 기능 작성

### DIFF
--- a/src/main/java/org/scoula/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/org/scoula/domain/member/mapper/MemberMapper.java
@@ -83,7 +83,9 @@ public interface MemberMapper {
 		        i.purpose,
 		        i.amount,
 		        i.transmit_fail_count,
-		        i.intermediary_bank_commission
+		        i.intermediary_bank_commission,
+		      	i.created_at,
+				i.updated_at
 		
 		    FROM member m
 		    JOIN remittance_information i ON m.remittance_information_id = i.remittance_information_id
@@ -108,5 +110,20 @@ public interface MemberMapper {
 		"</script>"
 	})
 	List<MemberWithInformationDto> findMembersWithInfoByGroupIds(@Param("groupIds") List<Long> groupIds);
+
+	void updateGroupIdByMemberIds(@Param("memberIds") List<Long> memberIds,
+		@Param("toGroupId") Long toGroupId);
+
+	@Select("""
+		<script>
+		  SELECT fcm_token
+		  FROM member
+		  WHERE member_id IN
+		  <foreach item='id' collection='memberIds' open='(' separator=',' close=')'>
+		    #{id}
+		  </foreach>
+		</script>
+		""")
+	List<String> findFcmTokensByMemberIds(@Param("memberIds") List<Long> memberIds);
 
 }

--- a/src/main/java/org/scoula/domain/member/service/MemberService.java
+++ b/src/main/java/org/scoula/domain/member/service/MemberService.java
@@ -1,11 +1,13 @@
 package org.scoula.domain.member.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 
 import org.scoula.domain.member.dto.MemberDTO;
 import org.scoula.domain.member.entity.Member;
+import org.scoula.domain.remittancegroup.batch.dto.MemberWithInformationDto;
 
 public interface MemberService {
 
@@ -31,4 +33,12 @@ public interface MemberService {
 
 	Member getMemberByPhoneNumber(String phoneNumber, HttpServletRequest request);
 
+	Optional<List<Member>> getMembersByRemittanceGroup(Long RemittanceGroupId);
+
+	Optional<List<MemberWithInformationDto>> getMemberWithRemittanceInformationByRemittanceGroupId(
+		Long RemittanceGroupId);
+
+	void changeRemittanceGroup(List<Long> memberIds, Long toGroupId);
+
+	void decreaseRemittanceGroupMemberCount(Long targetGroupId, int decreaseMemberCount);
 }

--- a/src/main/java/org/scoula/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/scoula/domain/member/service/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package org.scoula.domain.member.service;
 import static org.scoula.domain.member.exception.MemberErrorCode.*;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -10,6 +11,8 @@ import javax.servlet.http.HttpServletRequest;
 import org.scoula.domain.member.dto.MemberDTO;
 import org.scoula.domain.member.entity.Member;
 import org.scoula.domain.member.mapper.MemberMapper;
+import org.scoula.domain.remittancegroup.batch.dto.MemberWithInformationDto;
+import org.scoula.domain.remittancegroup.mapper.RemittanceGroupMapper;
 import org.scoula.global.exception.CustomException;
 import org.scoula.global.kafka.dto.Common;
 import org.scoula.global.kafka.dto.LogLevel;
@@ -28,6 +31,7 @@ public class MemberServiceImpl implements MemberService {
 
 	private final MemberMapper memberMapper;
 	private final PasswordEncoder passwordEncoder;
+	private final RemittanceGroupMapper remittanceGroupMapper;
 
 	@Override
 	public List<MemberDTO> getAllMembers() {
@@ -112,6 +116,31 @@ public class MemberServiceImpl implements MemberService {
 				.callApiPath(request.getRequestURI())
 				.deviceInfo(request.getHeader("user-agent"))
 				.build()));
+	}
+
+	@Override
+	public Optional<List<Member>> getMembersByRemittanceGroup(Long RemittanceGroupId) {
+		return Optional.of(memberMapper.findMembersByRemittanceGroupId(RemittanceGroupId));
+	}
+
+	@Override
+	public Optional<List<MemberWithInformationDto>> getMemberWithRemittanceInformationByRemittanceGroupId(
+		Long RemittanceGroupId) {
+		return Optional.of(memberMapper.findMembersWithInformationByGroupId(RemittanceGroupId));
+	}
+
+	@Override
+	@Transactional
+	public void changeRemittanceGroup(List<Long> memberIds, Long toGroupId) {
+		if (memberIds == null || memberIds.isEmpty())
+			return;
+		memberMapper.updateGroupIdByMemberIds(memberIds, toGroupId);
+	}
+
+	@Override
+	@Transactional
+	public void decreaseRemittanceGroupMemberCount(Long targetGroupId, int decreaseMemberCount) {
+		remittanceGroupMapper.decreaseMemberCountById(targetGroupId, decreaseMemberCount);
 	}
 
 }

--- a/src/main/java/org/scoula/domain/remittancegroup/batch/config/RemittanceAutoJoinBatchConfig.java
+++ b/src/main/java/org/scoula/domain/remittancegroup/batch/config/RemittanceAutoJoinBatchConfig.java
@@ -1,0 +1,78 @@
+package org.scoula.domain.remittancegroup.batch.config;
+
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+import org.scoula.domain.remittancegroup.batch.reader.IdRangePartitioner;
+import org.scoula.domain.remittancegroup.entity.RemittanceGroup;
+import org.scoula.domain.remittancegroup.mapper.RemittanceGroupMapper;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class RemittanceAutoJoinBatchConfig {
+
+	private final RemittanceGroupMapper remittanceGroupMapper;
+	private final MyBatisPagingItemReader<RemittanceGroup> remittanceGroupReader;
+	private final ItemWriter<RemittanceGroup> remittanceGroupWriter;
+
+	private final JobRepository jobRepository;
+	private final PlatformTransactionManager transactionManager;
+	private final StepBuilderFactory stepBuilderFactory;
+	private final TaskExecutor taskExecutor;
+
+	public RemittanceAutoJoinBatchConfig(RemittanceGroupMapper remittanceGroupMapper,
+		@Qualifier("autoJoinReader")
+		MyBatisPagingItemReader<RemittanceGroup> remittanceGroupReader,
+		@Qualifier("remittanceGroupAutoJoinItemWriter") ItemWriter<RemittanceGroup> remittanceGroupWriter,
+		JobRepository jobRepository, PlatformTransactionManager transactionManager,
+		StepBuilderFactory stepBuilderFactory,
+		TaskExecutor taskExecutor) {
+		this.remittanceGroupMapper = remittanceGroupMapper;
+		this.remittanceGroupReader = remittanceGroupReader;
+		this.remittanceGroupWriter = remittanceGroupWriter;
+		this.jobRepository = jobRepository;
+		this.transactionManager = transactionManager;
+		this.stepBuilderFactory = stepBuilderFactory;
+		this.taskExecutor = taskExecutor;
+	}
+
+	private final int threadSize = 3;
+
+	@Bean
+	public Job remittanceGroupAutoJoinJob() {
+		return new JobBuilder("remittanceGroupAutoJoinJob")
+			.start(partitionedRemittanceGroupAutoJoinStep())
+			.repository(jobRepository)
+			.build();
+	}
+
+	@Bean
+	public Step partitionedRemittanceGroupAutoJoinStep() {
+		return stepBuilderFactory.get("partitionedRemittanceGroupAutoJoinStep")
+			.partitioner("remittanceGroupAutoJoinStep", new IdRangePartitioner(remittanceGroupMapper))
+			.step(remittanceGroupAutoJoinStep())
+			.gridSize(threadSize)
+			.transactionManager(transactionManager)
+			.taskExecutor(taskExecutor)
+			.build();
+	}
+
+	@Bean
+	public Step remittanceGroupAutoJoinStep() {
+		return stepBuilderFactory.get("remittanceGroupAutoJoinStep")
+			.<RemittanceGroup, RemittanceGroup>chunk(1000)
+			.reader(remittanceGroupReader)
+			.writer(remittanceGroupWriter)
+			.repository(jobRepository)
+			.transactionManager(transactionManager)
+			.build();
+	}
+}

--- a/src/main/java/org/scoula/domain/remittancegroup/batch/config/RemittanceGroupBatchConfig.java
+++ b/src/main/java/org/scoula/domain/remittancegroup/batch/config/RemittanceGroupBatchConfig.java
@@ -10,15 +10,13 @@ import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.transaction.PlatformTransactionManager;
 
-import lombok.RequiredArgsConstructor;
-
 @Configuration
-@RequiredArgsConstructor
 public class RemittanceGroupBatchConfig {
 
 	private final ItemReader<RemittanceGroup> remittanceGroupReader;
@@ -31,6 +29,21 @@ public class RemittanceGroupBatchConfig {
 	private final TaskExecutor taskExecutor;
 
 	private final int threadSize = 3;
+
+	public RemittanceGroupBatchConfig(RemittanceGroupMapper remittanceGroupMapper,
+		ItemReader<RemittanceGroup> remittanceGroupReader,
+		@Qualifier("remittanceGroupItemWriter") ItemWriter<RemittanceGroup> remittanceGroupWriter,
+		JobRepository jobRepository, PlatformTransactionManager transactionManager,
+		StepBuilderFactory stepBuilderFactory,
+		TaskExecutor taskExecutor) {
+		this.remittanceGroupMapper = remittanceGroupMapper;
+		this.remittanceGroupReader = remittanceGroupReader;
+		this.remittanceGroupWriter = remittanceGroupWriter;
+		this.jobRepository = jobRepository;
+		this.transactionManager = transactionManager;
+		this.stepBuilderFactory = stepBuilderFactory;
+		this.taskExecutor = taskExecutor;
+	}
 
 	@Bean
 	public Job remittanceGroupJob() {

--- a/src/main/java/org/scoula/domain/remittancegroup/batch/dto/MemberWithInformationDto.java
+++ b/src/main/java/org/scoula/domain/remittancegroup/batch/dto/MemberWithInformationDto.java
@@ -2,6 +2,7 @@ package org.scoula.domain.remittancegroup.batch.dto;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.scoula.domain.remmitanceinformation.entity.IntermediaryBankCommission;
 import org.scoula.global.constants.Currency;
@@ -41,4 +42,6 @@ public class MemberWithInformationDto {
 	private BigDecimal amount;            // 환전을 원하는 금액(원화)
 	private Integer transmitFailCount;    // 송금 실패 카운트 (2회 이상 시 그룹 탈퇴)
 	private IntermediaryBankCommission intermediaryBankCommission; // 중계 수수료 부담 방식
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/scoula/domain/remittancegroup/batch/reader/RemittanceGroupAutoJoinReader.java
+++ b/src/main/java/org/scoula/domain/remittancegroup/batch/reader/RemittanceGroupAutoJoinReader.java
@@ -1,0 +1,36 @@
+package org.scoula.domain.remittancegroup.batch.reader;
+
+import java.util.Map;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+import org.scoula.domain.remittancegroup.entity.RemittanceGroup;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RemittanceGroupAutoJoinReader {
+
+	@Bean
+	@StepScope
+	public MyBatisPagingItemReader<RemittanceGroup> autoJoinReader(
+		@Value("#{stepExecutionContext['startId']}") Long startId,
+		@Value("#{stepExecutionContext['endId']}") Long endId,
+		@Qualifier("simpleSqlSessionFactory")
+		SqlSessionFactory sqlSessionFactory) {
+		MyBatisPagingItemReader<RemittanceGroup> reader = new MyBatisPagingItemReader<>();
+
+		reader.setQueryId(
+			"org.scoula.domain.remittancegroup.mapper.RemittanceGroupMapper.findByIdRangeBenefitStatusOn");
+		reader.setParameterValues(Map.of("startId", startId, "endId", endId));
+		reader.setSqlSessionFactory(sqlSessionFactory);
+		reader.setPageSize(1000);
+		reader.setSaveState(false);
+		reader.setName("autoJoinReader");
+
+		return reader;
+	}
+}

--- a/src/main/java/org/scoula/domain/remittancegroup/batch/writer/RemittanceGroupAutoJoinWriter.java
+++ b/src/main/java/org/scoula/domain/remittancegroup/batch/writer/RemittanceGroupAutoJoinWriter.java
@@ -1,0 +1,46 @@
+package org.scoula.domain.remittancegroup.batch.writer;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.scoula.domain.remittancegroup.entity.RemittanceGroup;
+import org.scoula.domain.remittancegroup.service.RemittanceService;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class RemittanceGroupAutoJoinWriter {
+
+	private final RemittanceService remittanceService;
+
+	@Bean("remittanceGroupAutoJoinItemWriter")
+	public ItemWriter<RemittanceGroup> remittanceGroupAutoJoinItemWriter() {
+		return items -> {
+			List<RemittanceGroup> sorted = new ArrayList<>(items);
+			sorted.sort(Comparator.comparingInt(g ->
+				g.getMemberCount() != null ? g.getMemberCount() : 0
+			));
+
+			if (log.isDebugEnabled()) {
+				for (RemittanceGroup g : sorted) {
+					log.debug("memberCount={}", g.getMemberCount());
+				}
+			}
+
+			for (RemittanceGroup g : sorted) {
+				// 기존 그룹에 이탈자가 없을 경우 패스
+				if (g.getMemberCount() != null && g.getMemberCount() >= 30)
+					continue;
+
+				remittanceService.changeRemittanceGroup(g);
+			}
+		};
+	}
+}

--- a/src/main/java/org/scoula/domain/remittancegroup/mapper/RemittanceGroupMapper.java
+++ b/src/main/java/org/scoula/domain/remittancegroup/mapper/RemittanceGroupMapper.java
@@ -105,6 +105,14 @@ public interface RemittanceGroupMapper {
 			SELECT *
 			FROM remittance_group
 			WHERE benefit_status IS NULL
+			  AND remittance_group_id BETWEEN #{startId} AND #{endId}
+		""")
+	List<RemittanceGroup> findByIdRangeBenefitStatusOn(@Param("startId") Long startId, @Param("endId") Long endId);
+
+	@Select("""
+			SELECT *
+			FROM remittance_group
+			WHERE benefit_status IS NULL
 		 		AND remittance_date = #{day}
 			  AND remittance_group_id BETWEEN #{startId} AND #{endId}
 			ORDER BY remittance_group_id
@@ -119,5 +127,32 @@ public interface RemittanceGroupMapper {
 		 		AND remittance_date = #{day}
 		""")
 	List<RemittanceGroup> findByDayBenefitOn(@Param("day") Integer day);
+
+	@Select("""
+			SELECT *
+			FROM remittance_group
+			WHERE benefit_status = 'OFF'
+		 		AND remittance_date = #{day}
+				AND currency = #{currency}
+			FOR UPDATE
+		""")
+	Optional<RemittanceGroup> findByDayAndCurrencyAndBenefitOFF(@Param("day") Integer day,
+		@Param("currency") Currency currency);
+
+	@Update("""
+		UPDATE remittance_group
+		SET member_count = GREATEST(member_count - #{memberCount}, 0)
+		WHERE remittance_group_id = #{remittanceGroupId}
+		""")
+	int decreaseMemberCountById(@Param("remittanceGroupId") Long remittanceGroupId,
+		@Param("memberCount") Integer memberCount);
+
+	@Update("""
+		UPDATE remittance_group
+		SET member_count = member_count + #{memberCount}
+		WHERE remittance_group_id = #{remittanceGroupId}
+		""")
+	int increaseMemberCountById(@Param("remittanceGroupId") Long remittanceGroupId,
+		@Param("memberCount") Integer memberCount);
 
 }

--- a/src/main/java/org/scoula/domain/remittancegroup/service/RemittanceService.java
+++ b/src/main/java/org/scoula/domain/remittancegroup/service/RemittanceService.java
@@ -8,6 +8,7 @@ import org.scoula.domain.member.entity.Member;
 import org.scoula.domain.remittancegroup.dto.request.JoinRemittanceGroupRequest;
 import org.scoula.domain.remittancegroup.dto.response.RemittanceGroupCommissionResponse;
 import org.scoula.domain.remittancegroup.dto.response.RemittanceGroupMemberCountResponse;
+import org.scoula.domain.remittancegroup.entity.RemittanceGroup;
 import org.scoula.global.constants.Currency;
 
 public interface RemittanceService {
@@ -21,4 +22,6 @@ public interface RemittanceService {
 		HttpServletRequest request);
 
 	void RemittanceGroupAlarm();
+
+	void changeRemittanceGroup(RemittanceGroup remittanceGroup);
 }

--- a/src/main/java/org/scoula/global/firebase/event/RemittanceGroupChangedEvent.java
+++ b/src/main/java/org/scoula/global/firebase/event/RemittanceGroupChangedEvent.java
@@ -1,0 +1,12 @@
+package org.scoula.global.firebase.event;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RemittanceGroupChangedEvent {
+	private final List<Long> memberIds;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,8 +19,6 @@ firebase.private.key.id=${FIREBASE_PRIVATE_KEY_ID}
 firebase.private.key=${FIREBASE_PRIVATE_KEY}
 firebase.client.email=${FIREBASE_CLIENT_EMAIL}
 firebase.client.id=${FIREBASE_CLIENT_ID}
-
-
 fss.api.key=${FSS_API_KEY}
 financial.company.api.url=${FINANCIAL_API_URL}
 fss.company.api.url=${FINANCIAL_COMPANY_API_URL}
@@ -28,5 +26,3 @@ deposit.product.list=${DEPOSIT_PRODUCT_LIST_BY_PERIOD_URL}
 deposit.product.detail.url.base=${PRODUCT_DETAIL_URL}
 saving.product.list=${SAVING_PRODUCT_LIST_BY_PERIOD_URL}
 saving.product.detail.url.base=${SAVING_DETAIL_URL}
-GPT_API_URL=${GPT_API_URL}
-GPT_API_KEY=${GPT_API_KEY}

--- a/src/main/resources/org/scoula/domain/member/mapper/MemberMapper.xml
+++ b/src/main/resources/org/scoula/domain/member/mapper/MemberMapper.xml
@@ -103,6 +103,15 @@
         WHERE member_id = #{memberId}
     </update>
 
+    <update id="updateGroupIdByMemberIds">
+        UPDATE member
+        SET remittance_group_id = #{toGroupId}
+        WHERE member_id IN
+        <foreach item="memberId" collection="memberIds" open="(" separator="," close=")">
+            #{memberId}
+        </foreach>
+    </update>
+
 
     <!-- 회원 삭제 -->
     <delete id="deleteMember" parameterType="long">

--- a/src/main/resources/org/scoula/domain/remittancegroup/.mapper/RemittanceGroupMapper.xml
+++ b/src/main/resources/org/scoula/domain/remittancegroup/.mapper/RemittanceGroupMapper.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.scoula.domain.remittancegroup.mapper.RemittanceGroupMapper">
+</mapper>


### PR DESCRIPTION
## 📌 관련 이슈
<!--- 관련 이슈를 태그해주세요 -->
- #101 
> Close #101 

## 📄 PR 상세 내용
<!--- 작업에 대한 설명을 작성해 주세요. -->
- 이탈한 회원을 체크하여 자동으로 신규 그룹에서 빼와 채우는 로직을 구현하였습니다.
- 그룹의 이탈자가 많은 순대로 먼저 채우며,
- 신규 그룹에서 가장 먼저 대기하고 있던 사람부터 빼와서 기존 그룹에 채우도록 하였습니다.
- 스케쥴러에 분산락을 적용해 중복 실행을 방지했습니다.

## 📸 이미지 (테스트 이미지 필수)
### 테스트 이전 그룹의 상태
<img width="1778" height="688" alt="image" src="https://github.com/user-attachments/assets/3b2b23c2-f224-4d46-8899-9a294d8eb37f" />

### 예상 결과
이후 예상 결과 
6조에 2명 넘거가고 7조는 0명이 됨

2조는 30명이 되고 3조는 0명이 됨

### 결과
<img width="2006" height="732" alt="image" src="https://github.com/user-attachments/assets/24e80ede-e28f-4d8e-bab2-e8347c77e528" />
예상 결과대로 바뀐 것을 확인할 수 있습니다.
