### PR TITLE
[Fix]: 공동 송금 그룹 가입 시 최대 송금 가능액 수정

### DIFF
--- a/src/main/java/org/scoula/domain/remittancegroup/dto/request/JoinRemittanceGroupRequest.java
+++ b/src/main/java/org/scoula/domain/remittancegroup/dto/request/JoinRemittanceGroupRequest.java
@@ -35,7 +35,7 @@ public record JoinRemittanceGroupRequest(
 	)
 	@NotNull(message = "송금 금액은 필수로 입력하셔야 합니다.")
 	@DecimalMin(value = "100000", inclusive = true, message = "송금 금액은 최소 10만원 이상이어야 합니다.")
-	@DecimalMax(value = "3000000", inclusive = true, message = "송금 금액은 최대 300만원 이하여야 합니다.")
+	@DecimalMax(value = "5000000", inclusive = true, message = "송금 금액은 최대 500만원 이하여야 합니다.")
 	BigDecimal amount,
 	@ApiModelProperty(
 		value = "송금 날짜",


### PR DESCRIPTION
<!--- 제목 ex: [Feat]: 회원가입 -->

## 📌 관련 이슈
<!--- 관련 이슈를 태그해주세요 -->
- #126 
> Close #126 

## 📄 PR 상세 내용
<!--- 작업에 대한 설명을 작성해 주세요. -->
- 공동 송금 그룹 가입 시 최대 송금 가능액을 300만원에서 500만원으로 수정하였습니다.

## 📸 이미지 (테스트 이미지 필수)
<img width="1044" height="1490" alt="image" src="https://github.com/user-attachments/assets/b31186e9-4a6d-4a9f-8889-b0b9e6ce828e" />
<img width="1072" height="1538" alt="image" src="https://github.com/user-attachments/assets/2da9d21f-bf4c-4c4a-b5b0-3962d85ebe2b" />

## ❓ 논의하고 싶은 내용

## 📍 레퍼런스
