### PR TITLE
[Fix] : 로그인에 제약 조건 걸기

### DIFF
--- a/src/main/java/org/scoula/domain/member/dto/request/JoinRequest.java
+++ b/src/main/java/org/scoula/domain/member/dto/request/JoinRequest.java
@@ -2,6 +2,8 @@ package org.scoula.domain.member.dto.request;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 
 import org.scoula.global.constants.NationalityCode;
 
@@ -10,12 +12,18 @@ import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel(description = "회원가입 요청 데이터")
 public record JoinRequest(
+
 	@ApiModelProperty(value = "로그인 아이디", example = "user123", required = true)
 	@NotBlank(message = "로그인 아이디는 필수 입력 값입니다.")
+	@Size(min = 6, message = "아이디는 6자 이상이어야 합니다.")
 	String loginId,
 
 	@ApiModelProperty(value = "비밀번호", example = "password123!", required = true)
 	@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+	@Pattern(
+		regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^a-zA-Z0-9]).{10,}$",
+		message = "비밀번호는 10자 이상이며, 영문 대소문자, 숫자, 특수문자를 모두 포함해야 합니다."
+	)
 	String password,
 
 	@ApiModelProperty(value = "휴대폰 번호", example = "01012345678", required = true)


### PR DESCRIPTION
## 📌 관련 이슈

- #127 
> Close #127 

## 📄 PR 상세 내용
- JoinRequest의 loginId에 최소 6자리 제약 조건 걸기
- password 영어 대소문자 포함, 숫자, 특수문자 포함, 10글자 이 제약

## 📸 이미지 (테스트 이미지 필수)
<img width="1536" height="1470" alt="image" src="https://github.com/user-attachments/assets/fc304378-ef39-4596-baa5-6fc2773823a5" />
<img width="1382" height="1478" alt="image" src="https://github.com/user-attachments/assets/831c0da1-c155-4ae2-821c-c33c424033a9" />
<img width="1602" height="1488" alt="image" src="https://github.com/user-attachments/assets/f73e7d63-bbe7-472a-9768-fea28430f0ec" />

## ❓ 논의하고 싶은 내용
<img width="2198" height="1536" alt="image" src="https://github.com/user-attachments/assets/3f086753-8445-4d3d-bce7-2a430d2b6365" />
휴대폰 인증을 하기 때문에 이게 상관이 없을지도 모르는데
이미 인증했던 핸드폰 다시 입력이 가능하긴 때문에 에러 처리를 해야 할수도 있을 것 같습니다.

## 📍 레퍼런스
