### PR TITLE
[Fix]: 거래내역 조회 시 기간 별 필터링이 에러 해결

### DIFF
--- a/src/main/java/org/scoula/global/constants/Period.java
+++ b/src/main/java/org/scoula/global/constants/Period.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum Period {
-	ONE_WEEK(7, ChronoUnit.WEEKS),
+	ONE_WEEK(7, ChronoUnit.DAYS),
 	ONE_MONTH(1, ChronoUnit.MONTHS),
 	THREE_MONTH(3, ChronoUnit.MONTHS),
 	SIX_MONTH(6, ChronoUnit.MONTHS),


### PR DESCRIPTION
## 📌 관련 이슈
<!--- 관련 이슈를 태그해주세요 -->
- #130 
> Close #130 

## 📄 PR 상세 내용
<!--- 작업에 대한 설명을 작성해 주세요. -->
- 일주일을 입력했을 때 맨 마지막 데이터가 조회되던 에러를 해결하였습니다.
- 계산식에 일주일이 아닌 49일을 빼도록 되어있었습니다.

## 📸 이미지 (테스트 이미지 필수)
<img width="1280" height="1398" alt="image" src="https://github.com/user-attachments/assets/170867bc-baae-4951-a6e2-f331d5c9c250" />
