### PR TITLE
[fix] 환율 정렬 수정

### DIFF
--- a/src/main/java/org/scoula/domain/exchange/dto/response/exchangeResponse/BankRateInfo.java
+++ b/src/main/java/org/scoula/domain/exchange/dto/response/exchangeResponse/BankRateInfo.java
@@ -30,7 +30,7 @@ public class BankRateInfo {
 
 	@ApiModelProperty(
 		value = "환율 표시 문자열",
-		example = "1 USD 당 1,419.4 KRW",
+		example = "1,419.4 KRW",
 		notes = "사용자에게 표시되는 환율 정보 (읽기 쉬운 형태)",
 		required = true,
 		position = 2

--- a/src/main/java/org/scoula/domain/exchange/service/policy/ExchangeRateService.java
+++ b/src/main/java/org/scoula/domain/exchange/service/policy/ExchangeRateService.java
@@ -142,8 +142,7 @@ public class ExchangeRateService {
 			targetExchange.getTargetExchange());
 
 		// 3. 환율 표시 문자열
-		String rateDisplay = String.format("1 %s 당 %s KRW",
-			targetExchange.getTargetExchange(),
+		String rateDisplay = String.format("%s KRW",
 			rateFormatter.format(actualRate));
 
 		// 4. 최종 금액 표시 문자열
@@ -170,10 +169,13 @@ public class ExchangeRateService {
 	private void sortBanksByAmount(List<BankRateInfo> banks, String exchangeType) {
 		if ("RECEIVE".equals(exchangeType) || "SELLCASH".equals(exchangeType)) {
 			// RECEIVE, SELLCASH: 원화를 받기 위해 필요한 외화가 적을수록 좋음 (오름차순)
-			banks.sort(Comparator.comparing(BankRateInfo::getTotaloperation));
+			banks.sort(Comparator.comparing(BankRateInfo::getTotaloperation)
+				.thenComparing(Comparator.comparing(BankRateInfo::getTargetoperation).reversed())
+			);
 		} else {
 			// SEND, GETCASH, BASE: 원화로 더 많은 외화를 받을수록 좋음 (내림차순)
-			banks.sort(Comparator.comparing(BankRateInfo::getTotaloperation).reversed());
+			banks.sort(Comparator.comparing(BankRateInfo::getTotaloperation).reversed()
+				.thenComparing(BankRateInfo::getTargetoperation));
 		}
 	}
 


### PR DESCRIPTION

## 📌 관련 이슈
<!--- 관련 이슈를 태그해주세요 -->
- #132 
> Close #132 

## 📄 PR 상세 내용
- 환율 정렬시 최종 환전 금액이 같을경우 1 기준 환율당 krw금액 기준으로 정렬 했습니다.
- 예를들어 MYR GETCASH(현찰을 받을때) 최종 금액이 작을수록 좋지만
- 최종 금액이 같은 경우 1 MYR당 krw는 클수록 좋게 정렬 했습니다.
- 1 기준환율 당을 제거 했습니다.
- 1 MYR 당 341.39 KRW 말고  341.39 KRW로 수정했습니다.


## 📸 이미지 (테스트 이미지 필수)
<img width="671" height="779" alt="스크린샷 2025-08-17 오후 10 21 09" src="https://github.com/user-attachments/assets/f9ead721-0f1d-47ad-a028-09be32879a6a" />

## ❓ 논의하고 싶은 내용

## 📍 레퍼런스
